### PR TITLE
TASK: Neos 9 Compatibility

### DIFF
--- a/Classes/Migration/Transformation/PropertyValueToLowercase.php
+++ b/Classes/Migration/Transformation/PropertyValueToLowercase.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Flowpack\SeoRouting\Migration\Transformation;
 
-use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
-use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
-use Neos\ContentRepository\NodeMigration\Transformation\NodeBasedTransformationInterface;
 use Neos\ContentRepository\Core\ContentRepository;
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\Feature\NodeModification\Command\SetNodeProperties;
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWrite;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepository\NodeMigration\Transformation\GlobalTransformationInterface;
+use Neos\ContentRepository\NodeMigration\Transformation\NodeBasedTransformationInterface;
 use Neos\ContentRepository\NodeMigration\Transformation\TransformationFactoryInterface;
 use Neos\ContentRepository\NodeMigration\Transformation\TransformationStep;
 
@@ -21,10 +21,14 @@ use Neos\ContentRepository\NodeMigration\Transformation\TransformationStep;
 class PropertyValueToLowercase implements TransformationFactoryInterface
 {
     /**
-     * @param array<string,string> $settings
+     * @inheritDoc
      */
-    public function build(array $settings, ContentRepository $contentRepository): GlobalTransformationInterface|NodeBasedTransformationInterface
+    public function build(
+        array $settings,
+        ContentRepository $contentRepository
+    ): GlobalTransformationInterface|NodeBasedTransformationInterface
     {
+        /** @var array{property: string} $settings */
         return new class(
             $settings['property']
         ) implements NodeBasedTransformationInterface {
@@ -36,25 +40,30 @@ class PropertyValueToLowercase implements TransformationFactoryInterface
                 $this->propertyName = $propertyName;
             }
 
-            public function execute(Node $node, DimensionSpacePointSet $coveredDimensionSpacePoints, WorkspaceName $workspaceNameForWriting): TransformationStep {
+            public function execute(
+                Node $node,
+                DimensionSpacePointSet $coveredDimensionSpacePoints,
+                WorkspaceName $workspaceNameForWriting
+            ): TransformationStep
+            {
                 $currentProperty = $node->getProperty($this->propertyName);
 
-                if ($currentProperty !== null && is_string($currentProperty)) {
-                    $value = strtolower($currentProperty);
-
-                    return TransformationStep::fromCommand(
-                        SetNodeProperties::create(
-                            $workspaceNameForWriting,
-                            $node->aggregateId,
-                            $node->originDimensionSpacePoint,
-                            PropertyValuesToWrite::fromArray([
-                                $this->propertyName => $value,
-                            ])
-                        )
-                    );
+                if (!is_string($currentProperty)) {
+                    return TransformationStep::createEmpty();
                 }
 
-                return TransformationStep::createEmpty();
+                $value = strtolower($currentProperty);
+
+                return TransformationStep::fromCommand(
+                    SetNodeProperties::create(
+                        $workspaceNameForWriting,
+                        $node->aggregateId,
+                        $node->originDimensionSpacePoint,
+                        PropertyValuesToWrite::fromArray([
+                            $this->propertyName => $value,
+                        ])
+                    )
+                );
             }
         };
     }

--- a/Classes/Migration/Transformation/PropertyValueToLowercase.php
+++ b/Classes/Migration/Transformation/PropertyValueToLowercase.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Flowpack\SeoRouting\Migration\Transformation;
 
-use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepository\NodeMigration\Transformation\NodeBasedTransformationInterface;
@@ -36,12 +36,12 @@ class PropertyValueToLowercase implements TransformationFactoryInterface
                 $this->propertyName = $propertyName;
             }
 
-            public function execute(Node $node, DimensionSpacePoint $coveredDimensionSpacePoints, WorkspaceName $workspaceNameForWriting): TransformationStep
-            {
+            public function execute(Node $node, DimensionSpacePointSet $coveredDimensionSpacePoints, WorkspaceName $workspaceNameForWriting): TransformationStep {
                 $currentProperty = $node->getProperty($this->propertyName);
 
                 if ($currentProperty !== null && is_string($currentProperty)) {
                     $value = strtolower($currentProperty);
+
                     return TransformationStep::fromCommand(
                         SetNodeProperties::create(
                             $workspaceNameForWriting,

--- a/Classes/Migration/Transformation/PropertyValueToLowercase.php
+++ b/Classes/Migration/Transformation/PropertyValueToLowercase.php
@@ -7,7 +7,8 @@ namespace Flowpack\SeoRouting\Migration\Transformation;
 use Neos\ContentRepository\Domain\Model\NodeData;
 use Neos\ContentRepository\Migration\Transformations\AbstractTransformation;
 
-class PropertyValueToLowercase extends AbstractTransformation
+// TODO 9.0 migration: You need to convert your AbstractTransformation to an implementation of Neos\ContentRepository\NodeMigration\Transformation\TransformationFactoryInterface
+class PropertyValueToLowercase
 {
     private string $propertyName;
 

--- a/Classes/Migration/Transformation/PropertyValueToLowercase.php
+++ b/Classes/Migration/Transformation/PropertyValueToLowercase.php
@@ -4,39 +4,58 @@ declare(strict_types=1);
 
 namespace Flowpack\SeoRouting\Migration\Transformation;
 
-use Neos\ContentRepository\Domain\Model\NodeData;
-use Neos\ContentRepository\Migration\Transformations\AbstractTransformation;
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use Neos\ContentRepository\NodeMigration\Transformation\NodeBasedTransformationInterface;
+use Neos\ContentRepository\Core\ContentRepository;
+use Neos\ContentRepository\Core\Feature\NodeModification\Command\SetNodeProperties;
+use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWrite;
+use Neos\ContentRepository\NodeMigration\Transformation\GlobalTransformationInterface;
+use Neos\ContentRepository\NodeMigration\Transformation\TransformationFactoryInterface;
+use Neos\ContentRepository\NodeMigration\Transformation\TransformationStep;
 
-// TODO 9.0 migration: You need to convert your AbstractTransformation to an implementation of Neos\ContentRepository\NodeMigration\Transformation\TransformationFactoryInterface
-class PropertyValueToLowercase
+/**
+ * Transforms a specified property value of a node to lowercase.
+ */
+class PropertyValueToLowercase implements TransformationFactoryInterface
 {
-    private string $propertyName;
-
-    public function setProperty(string $propertyName): void
-    {
-        $this->propertyName = $propertyName;
-    }
-
     /**
-     * @inheritDoc
+     * @param array<string,string> $settings
      */
-    public function isTransformable(NodeData $node)
+    public function build(array $settings, ContentRepository $contentRepository): GlobalTransformationInterface|NodeBasedTransformationInterface
     {
-        return $node->hasProperty($this->propertyName);
-    }
+        return new class(
+            $settings['property']
+        ) implements NodeBasedTransformationInterface {
 
-    /**
-     * @inheritDoc
-     */
-    public function execute(NodeData $node)
-    {
-        $currentPropertyValue = $node->getProperty($this->propertyName);
-        if (! is_string($currentPropertyValue)) {
-            return $node;
-        }
-        $newPropertyValue = strtolower($currentPropertyValue);
-        $node->setProperty($this->propertyName, $newPropertyValue);
+            private string $propertyName;
 
-        return $node;
+            public function __construct(string $propertyName)
+            {
+                $this->propertyName = $propertyName;
+            }
+
+            public function execute(Node $node, DimensionSpacePoint $coveredDimensionSpacePoints, WorkspaceName $workspaceNameForWriting): TransformationStep
+            {
+                $currentProperty = $node->getProperty($this->propertyName);
+
+                if ($currentProperty !== null && is_string($currentProperty)) {
+                    $value = strtolower($currentProperty);
+                    return TransformationStep::fromCommand(
+                        SetNodeProperties::create(
+                            $workspaceNameForWriting,
+                            $node->aggregateId,
+                            $node->originDimensionSpacePoint,
+                            PropertyValuesToWrite::fromArray([
+                                $this->propertyName => $value,
+                            ])
+                        )
+                    );
+                }
+
+                return TransformationStep::createEmpty();
+            }
+        };
     }
 }

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -15,3 +15,8 @@ Neos:
       middlewares:
         'after routing':
           middleware: 'Flowpack\SeoRouting\RoutingMiddleware'
+
+  ContentRepositoryRegistry:
+    nodeMigration:
+      transformationFactories:
+        PropertyValueToLowercase: Flowpack\SeoRouting\Migration\Transformation\PropertyValueToLowercase

--- a/Migrations/ContentRepository/Version20250124153030.yaml
+++ b/Migrations/ContentRepository/Version20250124153030.yaml
@@ -6,8 +6,7 @@ migration:
         settings:
           nodeType: "Neos.Neos:Document"
           withSubTypes: TRUE
-    # Custom transformation not possible in Neos < 9.0: https://neos-project.slack.com/archives/C04V4C6B0/p1752678184783919
-    # transformations:
-    #   - type: 'Flowpack\SeoRouting\Migration\Transformation\PropertyValueToLowercase'
-    #     settings:
-    #       property: "uriPathSegment"
+    transformations:
+      - type: 'PropertyValueToLowercase'
+        settings:
+          property: "uriPathSegment"

--- a/Migrations/ContentRepository/Version20250124153030.yaml
+++ b/Migrations/ContentRepository/Version20250124153030.yaml
@@ -1,16 +1,13 @@
-up:
-  comments: 'Transforms all uriPathSegment values to lowercase'
-  warnings: 'As this migration removes the distinction between uppercase and lowercase it might not be cleanly undone by the down migration.'
-  migration:
-    - filters:
-        - type: 'NodeType'
-          settings:
-            nodeType: 'Neos.Neos:Document'
-            withSubTypes: TRUE
-      transformations:
-        - type: 'Flowpack\SeoRouting\Migration\Transformation\PropertyValueToLowercase'
-          settings:
-            property: 'uriPathSegment'
-
-down:
-  comments: 'No down migration available'
+comments: "Transforms all uriPathSegment values to lowercase"
+warnings: "As this migration removes the distinction between uppercase and lowercase it might not be cleanly undone by the down migration."
+migration:
+  - filters:
+      - type: "NodeType"
+        settings:
+          nodeType: "Neos.Neos:Document"
+          withSubTypes: TRUE
+    # Custom transformation not possible in Neos < 9.0: https://neos-project.slack.com/archives/C04V4C6B0/p1752678184783919
+    # transformations:
+    #   - type: 'Flowpack\SeoRouting\Migration\Transformation\PropertyValueToLowercase'
+    #     settings:
+    #       property: "uriPathSegment"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ composer require flowpack/seo-routing
 If you want to use the *toLowerCase* feature you should execute the migration that comes with this package:
 
 ```
-./flow node:migrate 20250124153030 --confirmation true
+./flow nodemigration:execute 20250124153030 --force
 ```
 
 > [!WARNING]  

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "neos/neos": "^9.0"
   },
   "require-dev": {
+    "neos/contentrepositoryregistry-doctrinedbalclient": "*",
     "phpstan/phpstan": "^2.1",
     "phpstan/phpstan-phpunit": "^2.0",
     "phpstan/extension-installer": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   },
   "require-dev": {
     "neos/neos": "^9.0",
-    "neos/contentrepositoryregistry-doctrinedbalclient": "*",
+    "neos/contentrepositoryregistry-doctrinedbalclient": "^9.0@beta",
     "phpstan/phpstan": "^2.1",
     "phpstan/phpstan-phpunit": "^2.0",
     "phpstan/extension-installer": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,13 @@
   },
   "require": {
     "guzzlehttp/psr7": "^2.0",
-    "php": "^8.1",
-    "neos/neos": "^9.0"
+    "php": "^8.1"
+  },
+  "conflict": {
+    "neos/neos": "<9.0"
   },
   "require-dev": {
+    "neos/neos": "^9.0",
     "neos/contentrepositoryregistry-doctrinedbalclient": "*",
     "phpstan/phpstan": "^2.1",
     "phpstan/phpstan-phpunit": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "require": {
     "guzzlehttp/psr7": "^2.0",
     "php": "^8.1",
-    "neos/neos": "^8.3|^9.0"
+    "neos/neos": "^9.0"
   },
   "require-dev": {
     "phpstan/phpstan": "^2.1",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   },
   "require-dev": {
     "neos/neos": "^9.0",
-    "neos/contentrepositoryregistry-doctrinedbalclient": "^9.0@beta",
+    "neos/contentgraph-doctrinedbaladapter": "^9.0",
     "phpstan/phpstan": "^2.1",
     "phpstan/phpstan-phpunit": "^2.0",
     "phpstan/extension-installer": "^1.4",


### PR DESCRIPTION
Right now the installation and use of this package in neos 9 instance fails because of this TODO and the corresponding error:
`Required class "Neos\ContentRepository\Migration\Transformations\AbstractTransformation" could not be loaded properly for reflection from "Flowpack\SeoRouting\Migration\Transformation\PropertyValueToLowercase".`
Can somebody look into this? Thank you

Closes #17 